### PR TITLE
fix: update all pages with atmospheric backgrounds and fix text clipping

### DIFF
--- a/src/frontend/app/[locale]/imprint/page.tsx
+++ b/src/frontend/app/[locale]/imprint/page.tsx
@@ -9,29 +9,35 @@ export default function ImprintPage() {
   const t = useTranslations('navigation');
 
   return (
-    <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
-      <h1 className="mb-8 text-4xl font-bold">{t('imprint')}</h1>
-      <div className="prose prose-neutral dark:prose-invert max-w-none">
-        <h2>Angaben gemaess 5 TMG</h2>
-        <p>
-          Exostruction GmbH
-          <br />
-          Musterstrasse 1
-          <br />
-          12345 Musterstadt
-        </p>
+    <div className="relative">
+      <div className="absolute inset-0 -z-10">
+        <div className="absolute inset-0 bg-[linear-gradient(rgba(225,29,72,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(225,29,72,0.03)_1px,transparent_1px)] bg-[size:60px_60px] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_0%,black_70%,transparent_110%)]" />
+        <div className="absolute top-20 right-[15%] w-64 h-64 bg-[var(--primary)]/8 rounded-full blur-[100px]" />
+      </div>
+      <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+        <h1 className="text-gradient mb-8 text-4xl font-bold animate-fade-in-up [animation-delay:0.1s] opacity-0 [animation-fill-mode:forwards]">{t('imprint')}</h1>
+        <div className="prose prose-neutral dark:prose-invert max-w-none animate-fade-in-up [animation-delay:0.2s] opacity-0 [animation-fill-mode:forwards]">
+          <h2>Angaben gemaess 5 TMG</h2>
+          <p>
+            Exostruction GmbH
+            <br />
+            Musterstrasse 1
+            <br />
+            12345 Musterstadt
+          </p>
 
-        <h2>Kontakt</h2>
-        <p>
-          E-Mail: info@exostruction.com
-        </p>
+          <h2>Kontakt</h2>
+          <p>
+            E-Mail: info@exostruction.com
+          </p>
 
-        <h2>Haftungsausschluss</h2>
-        <p>
-          Die Inhalte dieser Seite wurden mit groesster Sorgfalt erstellt. Fuer die Richtigkeit,
-          Vollstaendigkeit und Aktualitaet der Inhalte koennen wir jedoch keine Gewaehr
-          uebernehmen.
-        </p>
+          <h2>Haftungsausschluss</h2>
+          <p>
+            Die Inhalte dieser Seite wurden mit groesster Sorgfalt erstellt. Fuer die Richtigkeit,
+            Vollstaendigkeit und Aktualitaet der Inhalte koennen wir jedoch keine Gewaehr
+            uebernehmen.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/frontend/app/[locale]/page.tsx
+++ b/src/frontend/app/[locale]/page.tsx
@@ -36,7 +36,7 @@ export default function HomePage() {
               <span className="block text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-bold leading-[0.9] tracking-tight">
                 {t('hero.title')}
               </span>
-              <span className="block text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-bold leading-[0.9] tracking-tight text-gradient mt-2">
+              <span className="block text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-bold leading-[1.1] tracking-tight text-gradient mt-2 pb-2">
                 {t('hero.titleHighlight')}
               </span>
             </h1>

--- a/src/frontend/app/[locale]/polls/[id]/page.tsx
+++ b/src/frontend/app/[locale]/polls/[id]/page.tsx
@@ -53,8 +53,11 @@ export default function PollPage() {
   // Loading state
   if (loading) {
     return (
-      <div className="relative overflow-hidden">
-        <div className="gradient-mesh absolute inset-0 -z-10" />
+      <div className="relative">
+        <div className="absolute inset-0 -z-10">
+          <div className="absolute inset-0 bg-[linear-gradient(rgba(225,29,72,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(225,29,72,0.03)_1px,transparent_1px)] bg-[size:60px_60px] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_0%,black_70%,transparent_110%)]" />
+          <div className="absolute top-20 right-[10%] w-64 h-64 bg-[var(--primary)]/10 rounded-full blur-[100px]" />
+        </div>
         <div className="mx-auto flex min-h-[60vh] max-w-3xl items-center justify-center px-4">
           <div className="text-center">
             <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-2 border-[var(--primary)] border-t-transparent" />
@@ -68,8 +71,11 @@ export default function PollPage() {
   // Error states
   if (error || !poll) {
     return (
-      <div className="relative overflow-hidden">
-        <div className="gradient-mesh absolute inset-0 -z-10" />
+      <div className="relative">
+        <div className="absolute inset-0 -z-10">
+          <div className="absolute inset-0 bg-[linear-gradient(rgba(225,29,72,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(225,29,72,0.03)_1px,transparent_1px)] bg-[size:60px_60px] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_0%,black_70%,transparent_110%)]" />
+          <div className="absolute top-20 right-[10%] w-64 h-64 bg-[var(--primary)]/10 rounded-full blur-[100px]" />
+        </div>
         <div className="mx-auto flex min-h-[60vh] max-w-lg flex-col items-center justify-center px-4">
           <Card glass className="w-full text-center">
             <AlertCircle className="mx-auto mb-4 h-12 w-12 text-[var(--destructive)]" />

--- a/src/frontend/app/[locale]/polls/create/page.tsx
+++ b/src/frontend/app/[locale]/polls/create/page.tsx
@@ -160,8 +160,11 @@ export default function CreatePollPage() {
   if (createdPollId) {
     const shareUrl = `${typeof window !== 'undefined' ? window.location.origin : ''}/polls/${createdPollId}`;
     return (
-      <div className="relative overflow-hidden">
-        <div className="gradient-mesh absolute inset-0 -z-10" />
+      <div className="relative">
+        <div className="absolute inset-0 -z-10">
+          <div className="absolute inset-0 bg-[linear-gradient(rgba(225,29,72,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(225,29,72,0.03)_1px,transparent_1px)] bg-[size:60px_60px] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_0%,black_70%,transparent_110%)]" />
+          <div className="absolute top-20 right-[10%] w-64 h-64 bg-[var(--primary)]/10 rounded-full blur-[100px]" />
+        </div>
         <div className="mx-auto flex min-h-[70vh] max-w-lg flex-col items-center justify-center px-4 py-12">
           <Card glass className="w-full text-center">
             <div className="mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full bg-green-500/10">
@@ -212,8 +215,12 @@ export default function CreatePollPage() {
   }
 
   return (
-    <div className="relative overflow-hidden">
-      <div className="gradient-mesh absolute inset-0 -z-10" />
+    <div className="relative">
+      <div className="absolute inset-0 -z-10">
+        <div className="absolute inset-0 bg-[linear-gradient(rgba(225,29,72,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(225,29,72,0.03)_1px,transparent_1px)] bg-[size:60px_60px] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_0%,black_70%,transparent_110%)]" />
+        <div className="absolute top-20 right-[10%] w-64 h-64 bg-[var(--primary)]/10 rounded-full blur-[100px]" />
+        <div className="absolute bottom-40 left-[5%] w-80 h-80 bg-[var(--primary)]/5 rounded-full blur-[120px]" />
+      </div>
       <div className="mx-auto max-w-2xl px-4 py-12">
         {/* Back link */}
         <Link

--- a/src/frontend/app/[locale]/polls/page.tsx
+++ b/src/frontend/app/[locale]/polls/page.tsx
@@ -6,33 +6,39 @@ export default function PollsPage() {
   const t = useTranslations('polls');
 
   return (
-    <div className="relative overflow-hidden">
-      {/* Background mesh */}
-      <div className="gradient-mesh absolute inset-0 -z-10" />
+    <div className="relative">
+      {/* Atmospheric Background */}
+      <div className="absolute inset-0 -z-10">
+        <div className="absolute inset-0 bg-[linear-gradient(rgba(225,29,72,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(225,29,72,0.03)_1px,transparent_1px)] bg-[size:60px_60px] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_0%,black_70%,transparent_110%)]" />
+        <div className="absolute top-20 left-[15%] w-64 h-64 bg-[var(--primary)]/10 rounded-full blur-[100px] animate-float" />
+        <div className="absolute bottom-40 right-[10%] w-80 h-80 bg-[var(--primary)]/5 rounded-full blur-[120px] animate-float [animation-delay:-3s]" />
+      </div>
 
       {/* Hero Section */}
       <section className="flex flex-col items-center justify-center px-4 pt-20 pb-12 text-center sm:pt-28 sm:pb-16">
-        <div className="animate-fade-in-up mx-auto max-w-3xl">
-          <h1 className="text-gradient mb-4 text-4xl font-bold tracking-tight sm:text-5xl">
+        <div className="mx-auto max-w-3xl">
+          <h1 className="animate-fade-in-up [animation-delay:0.1s] opacity-0 [animation-fill-mode:forwards] text-gradient mb-4 text-4xl font-bold tracking-tight sm:text-5xl">
             {t('list.title')}
           </h1>
-          <p className="mx-auto mb-8 max-w-xl text-lg text-[var(--muted-foreground)]">
+          <p className="animate-fade-in-up [animation-delay:0.2s] opacity-0 [animation-fill-mode:forwards] mx-auto mb-8 max-w-xl text-lg text-[var(--muted-foreground)]">
             {t('list.description')}
           </p>
-          <Link
-            href="/polls/create"
-            className="gradient-primary inline-flex items-center gap-2 rounded-xl px-8 py-4 text-lg font-semibold text-white shadow-lg transition-all duration-300 hover:scale-105 hover:shadow-xl"
-          >
-            <Plus className="h-5 w-5" />
-            {t('list.createCta')}
-          </Link>
+          <div className="animate-fade-in-up [animation-delay:0.3s] opacity-0 [animation-fill-mode:forwards]">
+            <Link
+              href="/polls/create"
+              className="gradient-primary inline-flex items-center gap-2 rounded-xl px-8 py-4 text-lg font-semibold text-white shadow-lg transition-all duration-300 hover:scale-105 hover:shadow-xl"
+            >
+              <Plus className="h-5 w-5" />
+              {t('list.createCta')}
+            </Link>
+          </div>
         </div>
       </section>
 
       {/* Feature highlights */}
       <section className="mx-auto max-w-5xl px-4 pb-20 sm:pb-28">
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
-          <div className="glass rounded-2xl border border-[var(--border)] p-6 text-center">
+          <div className="animate-fade-in-up [animation-delay:0.4s] opacity-0 [animation-fill-mode:forwards] glass rounded-2xl border border-[var(--border)] p-6 text-center transition-all duration-300 hover:scale-[1.02] hover:shadow-lg">
             <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--primary)]/10">
               <BarChart3 className="h-6 w-6 text-[var(--primary)]" />
             </div>
@@ -44,7 +50,7 @@ export default function PollsPage() {
             </p>
           </div>
 
-          <div className="glass rounded-2xl border border-[var(--border)] p-6 text-center">
+          <div className="animate-fade-in-up [animation-delay:0.5s] opacity-0 [animation-fill-mode:forwards] glass rounded-2xl border border-[var(--border)] p-6 text-center transition-all duration-300 hover:scale-[1.02] hover:shadow-lg">
             <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--primary)]/10">
               <Users className="h-6 w-6 text-[var(--primary)]" />
             </div>
@@ -56,7 +62,7 @@ export default function PollsPage() {
             </p>
           </div>
 
-          <div className="glass rounded-2xl border border-[var(--border)] p-6 text-center">
+          <div className="animate-fade-in-up [animation-delay:0.6s] opacity-0 [animation-fill-mode:forwards] glass rounded-2xl border border-[var(--border)] p-6 text-center transition-all duration-300 hover:scale-[1.02] hover:shadow-lg">
             <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--primary)]/10">
               <Clock className="h-6 w-6 text-[var(--primary)]" />
             </div>

--- a/src/frontend/app/[locale]/privacy/page.tsx
+++ b/src/frontend/app/[locale]/privacy/page.tsx
@@ -9,33 +9,39 @@ export default function PrivacyPage() {
   const t = useTranslations('navigation');
 
   return (
-    <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
-      <h1 className="mb-8 text-4xl font-bold">{t('privacy')}</h1>
-      <div className="prose prose-neutral dark:prose-invert max-w-none">
-        <h2>1. Datenschutz auf einen Blick</h2>
-        <h3>Allgemeine Hinweise</h3>
-        <p>
-          Die folgenden Hinweise geben einen einfachen Ueberblick darueber, was mit Ihren
-          personenbezogenen Daten passiert, wenn Sie diese Website besuchen.
-        </p>
+    <div className="relative">
+      <div className="absolute inset-0 -z-10">
+        <div className="absolute inset-0 bg-[linear-gradient(rgba(225,29,72,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(225,29,72,0.03)_1px,transparent_1px)] bg-[size:60px_60px] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_0%,black_70%,transparent_110%)]" />
+        <div className="absolute top-20 right-[15%] w-64 h-64 bg-[var(--primary)]/8 rounded-full blur-[100px]" />
+      </div>
+      <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+        <h1 className="text-gradient mb-8 text-4xl font-bold animate-fade-in-up [animation-delay:0.1s] opacity-0 [animation-fill-mode:forwards]">{t('privacy')}</h1>
+        <div className="prose prose-neutral dark:prose-invert max-w-none animate-fade-in-up [animation-delay:0.2s] opacity-0 [animation-fill-mode:forwards]">
+          <h2>1. Datenschutz auf einen Blick</h2>
+          <h3>Allgemeine Hinweise</h3>
+          <p>
+            Die folgenden Hinweise geben einen einfachen Ueberblick darueber, was mit Ihren
+            personenbezogenen Daten passiert, wenn Sie diese Website besuchen.
+          </p>
 
-        <h2>2. Datenerfassung auf dieser Website</h2>
-        <h3>Cookies</h3>
-        <p>
-          Unsere Internetseiten verwenden teilweise so genannte Cookies. Cookies richten auf Ihrem
-          Rechner keinen Schaden an und enthalten keine Viren.
-        </p>
+          <h2>2. Datenerfassung auf dieser Website</h2>
+          <h3>Cookies</h3>
+          <p>
+            Unsere Internetseiten verwenden teilweise so genannte Cookies. Cookies richten auf Ihrem
+            Rechner keinen Schaden an und enthalten keine Viren.
+          </p>
 
-        <h2>3. Hosting</h2>
-        <p>
-          Wir hosten die Inhalte unserer Website bei folgendem Anbieter.
-        </p>
+          <h2>3. Hosting</h2>
+          <p>
+            Wir hosten die Inhalte unserer Website bei folgendem Anbieter.
+          </p>
 
-        <h2>4. Ihre Rechte</h2>
-        <p>
-          Sie haben jederzeit das Recht, unentgeltlich Auskunft ueber Herkunft, Empfaenger und
-          Zweck Ihrer gespeicherten personenbezogenen Daten zu erhalten.
-        </p>
+          <h2>4. Ihre Rechte</h2>
+          <p>
+            Sie haben jederzeit das Recht, unentgeltlich Auskunft ueber Herkunft, Empfaenger und
+            Zweck Ihrer gespeicherten personenbezogenen Daten zu erhalten.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/frontend/styles/globals.css
+++ b/src/frontend/styles/globals.css
@@ -167,6 +167,9 @@ body {
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+  padding-bottom: 0.1em;
 }
 
 /* Keyframes */


### PR DESCRIPTION
## Summary
- Fixes text-gradient descender clipping globally (the "g" getting cut off) by adding `padding-bottom` and `box-decoration-break` to `.text-gradient` CSS
- Removes `overflow-hidden` wrappers from all pages that caused clipping
- Replaces basic `gradient-mesh` backgrounds with grid overlay + floating orbs pattern (consistent with hero redesign from #4)
- Adds staggered entrance animations and hover effects to polls listing page
- Adds atmospheric backgrounds and gradient text headings to legal pages (imprint, privacy)

## Test plan
- [ ] Verify "g" descenders render fully on all pages with gradient text
- [ ] Check atmospheric backgrounds appear on polls listing, create, view, imprint, and privacy pages
- [ ] Confirm staggered animations on polls listing page
- [ ] Test both dark and light themes
- [ ] Verify responsive behavior on mobile/tablet/desktop

Relates to #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)