### PR TITLE
fix: add drag-and-drop, validation, and improved results for ranked-choice voting

### DIFF
--- a/src/backend/Exo.Vote.Application/Features/Polls/Commands/CastVote/CastVoteCommandHandler.cs
+++ b/src/backend/Exo.Vote.Application/Features/Polls/Commands/CastVote/CastVoteCommandHandler.cs
@@ -68,6 +68,34 @@ public sealed class CastVoteCommandHandler : ICommandHandler<CastVoteCommand, Ca
             throw new InvalidOperationException("Single choice polls allow only one selection");
         }
 
+        // For Ranked polls, validate all options are ranked with proper sequential ranks
+        if (poll.Type == PollType.Ranked)
+        {
+            if (command.Selections.Count != poll.Options.Count)
+            {
+                throw new InvalidOperationException("All options must be ranked in a ranked poll");
+            }
+
+            if (command.Selections.Any(s => !s.Rank.HasValue))
+            {
+                throw new InvalidOperationException("All selections must include a rank for ranked polls");
+            }
+
+            var ranks = command.Selections.Select(s => s.Rank!.Value).OrderBy(r => r).ToList();
+            if (ranks.First() != 1 || ranks.Last() != poll.Options.Count)
+            {
+                throw new InvalidOperationException("Ranks must be sequential starting at 1");
+            }
+
+            for (int i = 0; i < ranks.Count; i++)
+            {
+                if (ranks[i] != i + 1)
+                {
+                    throw new InvalidOperationException("Ranks must be sequential with no gaps or duplicates");
+                }
+            }
+        }
+
         // Create vote records
         var voterId = Guid.NewGuid().ToString();
         foreach (var selection in command.Selections)

--- a/src/backend/Exo.Vote.Application/Features/Polls/Commands/CastVote/CastVoteCommandValidator.cs
+++ b/src/backend/Exo.Vote.Application/Features/Polls/Commands/CastVote/CastVoteCommandValidator.cs
@@ -23,5 +23,41 @@ public sealed class CastVoteCommandValidator : AbstractValidator<CastVoteCommand
                 selection.RuleFor(s => s.OptionId)
                     .NotEmpty().WithMessage("Option ID is required");
             });
+
+        // Ranked poll validation: when ranks are provided, they must be valid
+        RuleFor(x => x.Selections)
+            .Must(selections =>
+            {
+                // Only apply if any selection has a rank
+                if (!selections.Any(s => s.Rank.HasValue))
+                    return true;
+
+                // All selections must have ranks
+                if (selections.Any(s => !s.Rank.HasValue))
+                    return false;
+
+                var ranks = selections.Select(s => s.Rank!.Value).OrderBy(r => r).ToList();
+
+                // Ranks must start at 1
+                if (ranks.First() != 1)
+                    return false;
+
+                // Ranks must be sequential (1, 2, 3, ...)
+                for (int i = 0; i < ranks.Count; i++)
+                {
+                    if (ranks[i] != i + 1)
+                        return false;
+                }
+
+                return true;
+            })
+            .WithMessage("Ranks must be sequential starting at 1 with no duplicates")
+            .When(x => x.Selections != null && x.Selections.Count > 0);
+
+        // No duplicate option IDs
+        RuleFor(x => x.Selections)
+            .Must(selections => selections.Select(s => s.OptionId).Distinct().Count() == selections.Count)
+            .WithMessage("Duplicate option selections are not allowed")
+            .When(x => x.Selections != null && x.Selections.Count > 0);
     }
 }

--- a/src/backend/Exo.Vote.Tests/Features/Polls/Commands/CastVoteValidatorTests.cs
+++ b/src/backend/Exo.Vote.Tests/Features/Polls/Commands/CastVoteValidatorTests.cs
@@ -72,4 +72,132 @@ public class CastVoteValidatorTests
         var result = _validator.TestValidate(command);
         result.ShouldHaveValidationErrorFor(x => x.Selections);
     }
+
+    [Fact]
+    public void Validate_ValidRankedSelections_ShouldNotHaveErrors()
+    {
+        var command = new CastVoteCommand(
+            PollId: Guid.NewGuid(),
+            VoterName: "Alice",
+            Selections: new List<VoteSelection>
+            {
+                new(Guid.NewGuid(), 1),
+                new(Guid.NewGuid(), 2),
+                new(Guid.NewGuid(), 3)
+            }
+        );
+
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_RankedWithDuplicateRanks_ShouldHaveError()
+    {
+        var command = new CastVoteCommand(
+            PollId: Guid.NewGuid(),
+            VoterName: "Alice",
+            Selections: new List<VoteSelection>
+            {
+                new(Guid.NewGuid(), 1),
+                new(Guid.NewGuid(), 1),
+                new(Guid.NewGuid(), 3)
+            }
+        );
+
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Selections)
+            .WithErrorMessage("Ranks must be sequential starting at 1 with no duplicates");
+    }
+
+    [Fact]
+    public void Validate_RankedNotStartingAt1_ShouldHaveError()
+    {
+        var command = new CastVoteCommand(
+            PollId: Guid.NewGuid(),
+            VoterName: "Alice",
+            Selections: new List<VoteSelection>
+            {
+                new(Guid.NewGuid(), 0),
+                new(Guid.NewGuid(), 1),
+                new(Guid.NewGuid(), 2)
+            }
+        );
+
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Selections);
+    }
+
+    [Fact]
+    public void Validate_RankedWithGaps_ShouldHaveError()
+    {
+        var command = new CastVoteCommand(
+            PollId: Guid.NewGuid(),
+            VoterName: "Alice",
+            Selections: new List<VoteSelection>
+            {
+                new(Guid.NewGuid(), 1),
+                new(Guid.NewGuid(), 3),
+                new(Guid.NewGuid(), 5)
+            }
+        );
+
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Selections);
+    }
+
+    [Fact]
+    public void Validate_RankedMixedNullAndNonNullRanks_ShouldHaveError()
+    {
+        var command = new CastVoteCommand(
+            PollId: Guid.NewGuid(),
+            VoterName: "Alice",
+            Selections: new List<VoteSelection>
+            {
+                new(Guid.NewGuid(), 1),
+                new(Guid.NewGuid()),
+                new(Guid.NewGuid(), 3)
+            }
+        );
+
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Selections);
+    }
+
+    [Fact]
+    public void Validate_DuplicateOptionIds_ShouldHaveError()
+    {
+        var optionId = Guid.NewGuid();
+        var command = new CastVoteCommand(
+            PollId: Guid.NewGuid(),
+            VoterName: "Alice",
+            Selections: new List<VoteSelection>
+            {
+                new(optionId, 1),
+                new(optionId, 2)
+            }
+        );
+
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Selections)
+            .WithErrorMessage("Duplicate option selections are not allowed");
+    }
+
+    [Fact]
+    public void Validate_RankedWithNegativeRank_ShouldHaveError()
+    {
+        var command = new CastVoteCommand(
+            PollId: Guid.NewGuid(),
+            VoterName: "Alice",
+            Selections: new List<VoteSelection>
+            {
+                new(Guid.NewGuid(), -1),
+                new(Guid.NewGuid(), 0),
+                new(Guid.NewGuid(), 1)
+            }
+        );
+
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Selections);
+    }
 }

--- a/src/frontend/__tests__/components/polls/RankedVoting.test.tsx
+++ b/src/frontend/__tests__/components/polls/RankedVoting.test.tsx
@@ -58,4 +58,20 @@ describe('RankedVoting', () => {
     const moveDownButtons = screen.getAllByRole('button', { name: 'Move down' });
     expect(moveDownButtons[2]).toBeDisabled();
   });
+
+  it('renders drag handles for each option', () => {
+    render(
+      <RankedVoting options={mockOptions} ranking={['1', '2', '3']} onRankingChange={vi.fn()} />,
+    );
+    const dragHandles = screen.getAllByRole('button', { name: 'Drag to reorder' });
+    expect(dragHandles).toHaveLength(3);
+  });
+
+  it('renders as a list with proper role', () => {
+    render(
+      <RankedVoting options={mockOptions} ranking={['1', '2', '3']} onRankingChange={vi.fn()} />,
+    );
+    expect(screen.getByRole('list', { name: 'Ranked options' })).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+  });
 });

--- a/src/frontend/__tests__/components/polls/VotingForm.test.tsx
+++ b/src/frontend/__tests__/components/polls/VotingForm.test.tsx
@@ -56,4 +56,50 @@ describe('VotingForm', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Abstimmen' }));
     expect(screen.getByText('Bitte wähle mindestens eine Option')).toBeInTheDocument();
   });
+
+  it('shows validation error when submitting ranked poll without reordering', () => {
+    const rankedPoll: Poll = {
+      ...basePoll,
+      type: 'Ranked',
+      options: [
+        { id: '1', text: 'Option A', sortOrder: 0, voteCount: 0 },
+        { id: '2', text: 'Option B', sortOrder: 1, voteCount: 0 },
+        { id: '3', text: 'Option C', sortOrder: 2, voteCount: 0 },
+      ],
+    };
+    render(<VotingForm poll={rankedPoll} onVoteSubmitted={vi.fn()} />);
+    // Fill in name but don't reorder
+    fireEvent.change(screen.getByPlaceholderText('Gib deinen Namen ein'), {
+      target: { value: 'Test User' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Abstimmen' }));
+    expect(screen.getByText('Bitte ordne alle Optionen')).toBeInTheDocument();
+  });
+
+  it('clears ranked validation error after reordering', () => {
+    const rankedPoll: Poll = {
+      ...basePoll,
+      type: 'Ranked',
+      options: [
+        { id: '1', text: 'Option A', sortOrder: 0, voteCount: 0 },
+        { id: '2', text: 'Option B', sortOrder: 1, voteCount: 0 },
+        { id: '3', text: 'Option C', sortOrder: 2, voteCount: 0 },
+      ],
+    };
+    render(<VotingForm poll={rankedPoll} onVoteSubmitted={vi.fn()} />);
+    // Fill in name
+    fireEvent.change(screen.getByPlaceholderText('Gib deinen Namen ein'), {
+      target: { value: 'Test User' },
+    });
+    // Submit without reordering
+    fireEvent.click(screen.getByRole('button', { name: 'Abstimmen' }));
+    expect(screen.getByText('Bitte ordne alle Optionen')).toBeInTheDocument();
+
+    // Reorder by clicking move down on first item
+    const moveDownButtons = screen.getAllByRole('button', { name: 'Move down' });
+    fireEvent.click(moveDownButtons[0]);
+
+    // Validation error should be cleared
+    expect(screen.queryByText('Bitte ordne alle Optionen')).not.toBeInTheDocument();
+  });
 });

--- a/src/frontend/components/polls/PollResults.tsx
+++ b/src/frontend/components/polls/PollResults.tsx
@@ -138,6 +138,7 @@ export function PollResults({ pollId, pollType }: PollResultsProps) {
   });
 
   const maxVotes = Math.max(...results.options.map((o) => o.voteCount), 1);
+  const isRanked = pollType === 'Ranked';
 
   return (
     <Card glass>
@@ -184,7 +185,8 @@ export function PollResults({ pollId, pollType }: PollResultsProps) {
               pollType={pollType}
               isExpanded={expandedOptions.has(option.id)}
               onToggleVoters={() => toggleVoters(option.id)}
-              isLeader={index === 0 && option.voteCount > 0}
+              isLeader={index === 0 && (isRanked ? option.averageRank != null : option.voteCount > 0)}
+              optionCount={results.options.length}
             />
           ))}
         </div>
@@ -202,6 +204,7 @@ type ResultOptionProps = {
   isExpanded: boolean;
   onToggleVoters: () => void;
   isLeader: boolean;
+  optionCount: number;
 };
 
 function ResultOption({
@@ -212,10 +215,17 @@ function ResultOption({
   isExpanded,
   onToggleVoters,
   isLeader,
+  optionCount,
 }: ResultOptionProps) {
   const t = useTranslations('polls.results');
 
-  const barWidth = totalVotes > 0 ? (option.voteCount / maxVotes) * 100 : 0;
+  const isRanked = pollType === 'Ranked';
+  // For ranked polls, show bar based on inverse average rank (lower rank = better = wider bar)
+  const rankedBarWidth = isRanked && option.averageRank != null && optionCount > 1
+    ? ((optionCount - option.averageRank + 1) / optionCount) * 100
+    : 0;
+  const standardBarWidth = totalVotes > 0 ? (option.voteCount / maxVotes) * 100 : 0;
+  const barWidth = isRanked ? rankedBarWidth : standardBarWidth;
 
   return (
     <div className="space-y-1.5">
@@ -226,15 +236,20 @@ function ResultOption({
           <span className="text-sm font-medium">{option.text}</span>
         </div>
         <div className="flex items-center gap-2 text-xs text-[var(--muted-foreground)]">
-          {pollType === 'Ranked' && option.averageRank != null && (
-            <span>{t('averageRank', { rank: option.averageRank.toFixed(1) })}</span>
+          {isRanked && option.averageRank != null ? (
+            <span className="font-semibold tabular-nums">
+              {t('averageRank', { rank: option.averageRank.toFixed(1) })}
+            </span>
+          ) : (
+            <>
+              <span className="font-semibold tabular-nums">
+                {option.voteCount}
+              </span>
+              <span>
+                ({t('percentage', { value: totalVotes > 0 ? Math.round((option.voteCount / totalVotes) * 100) : 0 })})
+              </span>
+            </>
           )}
-          <span className="font-semibold tabular-nums">
-            {option.voteCount}
-          </span>
-          <span>
-            ({t('percentage', { value: totalVotes > 0 ? Math.round((option.voteCount / totalVotes) * 100) : 0 })})
-          </span>
         </div>
       </div>
 

--- a/src/frontend/components/polls/RankedVoting.tsx
+++ b/src/frontend/components/polls/RankedVoting.tsx
@@ -1,6 +1,22 @@
 'use client';
 
 import { useCallback } from 'react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { ArrowUp, ArrowDown, GripVertical } from 'lucide-react';
 import clsx from 'clsx';
 import type { PollOption } from '@/lib/types';
@@ -13,6 +29,15 @@ type RankedVotingProps = {
 };
 
 export function RankedVoting({ options, ranking, onRankingChange, disabled }: RankedVotingProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 5 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
   const moveUp = useCallback(
     (index: number) => {
       if (index === 0) return;
@@ -33,47 +58,133 @@ export function RankedVoting({ options, ranking, onRankingChange, disabled }: Ra
     [ranking, onRankingChange],
   );
 
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const oldIndex = ranking.indexOf(active.id as string);
+      const newIndex = ranking.indexOf(over.id as string);
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const newRanking = [...ranking];
+      newRanking.splice(oldIndex, 1);
+      newRanking.splice(newIndex, 0, active.id as string);
+      onRankingChange(newRanking);
+    },
+    [ranking, onRankingChange],
+  );
+
   const getOptionText = (optionId: string) => {
     return options.find((o) => o.id === optionId)?.text ?? '';
   };
 
   return (
-    <div className="space-y-2">
-      {ranking.map((optionId, index) => (
-        <div
-          key={optionId}
-          className={clsx(
-            'flex items-center gap-3 rounded-xl border border-[var(--border)] p-4 transition-all duration-200',
-            disabled && 'pointer-events-none opacity-60',
-          )}
-        >
-          <GripVertical className="h-4 w-4 shrink-0 text-[var(--muted-foreground)]" />
-          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--primary)] text-xs font-bold text-white">
-            {index + 1}
-          </span>
-          <span className="flex-1 text-sm font-medium">{getOptionText(optionId)}</span>
-          <div className="flex gap-1">
-            <button
-              type="button"
-              onClick={() => moveUp(index)}
-              disabled={index === 0 || disabled}
-              className="rounded-lg p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-30"
-              aria-label="Move up"
-            >
-              <ArrowUp className="h-4 w-4" />
-            </button>
-            <button
-              type="button"
-              onClick={() => moveDown(index)}
-              disabled={index === ranking.length - 1 || disabled}
-              className="rounded-lg p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-30"
-              aria-label="Move down"
-            >
-              <ArrowDown className="h-4 w-4" />
-            </button>
-          </div>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext items={ranking} strategy={verticalListSortingStrategy}>
+        <div className="space-y-2" role="list" aria-label="Ranked options">
+          {ranking.map((optionId, index) => (
+            <SortableItem
+              key={optionId}
+              id={optionId}
+              index={index}
+              text={getOptionText(optionId)}
+              isFirst={index === 0}
+              isLast={index === ranking.length - 1}
+              disabled={disabled}
+              onMoveUp={() => moveUp(index)}
+              onMoveDown={() => moveDown(index)}
+            />
+          ))}
         </div>
-      ))}
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+type SortableItemProps = {
+  id: string;
+  index: number;
+  text: string;
+  isFirst: boolean;
+  isLast: boolean;
+  disabled?: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+};
+
+function SortableItem({
+  id,
+  index,
+  text,
+  isFirst,
+  isLast,
+  disabled,
+  onMoveUp,
+  onMoveDown,
+}: SortableItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id, disabled });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      role="listitem"
+      className={clsx(
+        'flex items-center gap-3 rounded-xl border border-[var(--border)] p-4 transition-all duration-200',
+        disabled && 'pointer-events-none opacity-60',
+        isDragging && 'z-50 shadow-lg opacity-90 border-[var(--primary)]',
+      )}
+    >
+      <button
+        type="button"
+        className="cursor-grab touch-none text-[var(--muted-foreground)] hover:text-[var(--foreground)] active:cursor-grabbing"
+        aria-label="Drag to reorder"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-4 w-4 shrink-0" />
+      </button>
+      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--primary)] text-xs font-bold text-white">
+        {index + 1}
+      </span>
+      <span className="flex-1 text-sm font-medium">{text}</span>
+      <div className="flex gap-1">
+        <button
+          type="button"
+          onClick={onMoveUp}
+          disabled={isFirst || disabled}
+          className="rounded-lg p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-30"
+          aria-label="Move up"
+        >
+          <ArrowUp className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={onMoveDown}
+          disabled={isLast || disabled}
+          className="rounded-lg p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-30"
+          aria-label="Move down"
+        >
+          <ArrowDown className="h-4 w-4" />
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/frontend/components/polls/VotingForm.tsx
+++ b/src/frontend/components/polls/VotingForm.tsx
@@ -23,9 +23,9 @@ export function VotingForm({ poll, onVoteSubmitted }: VotingFormProps) {
   const [voterName, setVoterName] = useState('');
   const [singleChoice, setSingleChoice] = useState<string | null>(null);
   const [multipleChoices, setMultipleChoices] = useState<string[]>([]);
-  const [ranking, setRanking] = useState<string[]>(
-    poll.options.map((o) => o.id),
-  );
+  const initialRanking = poll.options.map((o) => o.id);
+  const [ranking, setRanking] = useState<string[]>(initialRanking);
+  const [hasReordered, setHasReordered] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [nameError, setNameError] = useState<string | null>(null);
@@ -56,6 +56,11 @@ export function VotingForm({ poll, onVoteSubmitted }: VotingFormProps) {
 
     if (poll.type === 'MultipleChoice' && multipleChoices.length === 0) {
       setSelectionError(t('vote.validation.selectionRequired'));
+      valid = false;
+    }
+
+    if (poll.type === 'Ranked' && !hasReordered) {
+      setSelectionError(t('vote.validation.rankingRequired'));
       valid = false;
     }
 
@@ -159,7 +164,11 @@ export function VotingForm({ poll, onVoteSubmitted }: VotingFormProps) {
               <RankedVoting
                 options={poll.options}
                 ranking={ranking}
-                onRankingChange={setRanking}
+                onRankingChange={(newRanking) => {
+                  setRanking(newRanking);
+                  setHasReordered(true);
+                  setSelectionError(null);
+                }}
               />
             </>
           )}

--- a/src/frontend/messages/de.json
+++ b/src/frontend/messages/de.json
@@ -104,7 +104,7 @@
       "selectOption": "Wähle eine Option",
       "selectOptions": "Wähle eine oder mehrere Optionen",
       "rankOptions": "Ordne die Optionen nach Präferenz",
-      "rankHelp": "Ziehe die Optionen in die gewünschte Reihenfolge (1 = beste Wahl)",
+      "rankHelp": "Ziehe oder verwende die Pfeiltasten, um die Reihenfolge zu ändern (1 = beste Wahl)",
       "success": "Deine Stimme wurde erfolgreich abgegeben!",
       "validation": {
         "nameRequired": "Dein Name ist erforderlich",

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -104,7 +104,7 @@
       "selectOption": "Select an option",
       "selectOptions": "Select one or more options",
       "rankOptions": "Rank the options by preference",
-      "rankHelp": "Drag options into your preferred order (1 = top choice)",
+      "rankHelp": "Drag or use the arrow buttons to reorder options (1 = top choice)",
       "success": "Your vote has been submitted successfully!",
       "validation": {
         "nameRequired": "Your name is required",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -11,6 +11,9 @@
     "test:coverage": "vitest --coverage"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@microsoft/signalr": "^10.0.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.500.0",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@microsoft/signalr':
         specifier: ^10.0.0
         version: 10.0.0
@@ -217,6 +226,28 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -3207,6 +3238,31 @@ snapshots:
   '@csstools/css-syntax-patches-for-csstree@1.0.27': {}
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@emnapi/core@1.8.1':
     dependencies:


### PR DESCRIPTION
## Summary
- Implements drag-and-drop reordering for ranked poll options using `@dnd-kit/core` + `@dnd-kit/sortable`, keeping arrow buttons as accessible fallback
- Adds frontend validation requiring users to actively reorder options before submitting (prevents meaningless default-order votes)
- Adds backend validation in both `CastVoteCommandValidator` (sequential ranks, no duplicates, no duplicate options) and `CastVoteCommandHandler` (all poll options must be ranked for ranked polls)
- Improves ranked poll results display: emphasizes average rank, hides confusing vote count/percentage for ranked polls, uses inverse-rank bar width
- Updates i18n text (de/en) to accurately describe both drag-and-drop and arrow button interactions

## Test plan
- [x] Backend: 12 validator tests pass (7 new: sequential ranks, duplicate ranks, gaps, negative ranks, mixed null/non-null, duplicate options, valid ranked)
- [x] Frontend: 42 tests pass (4 new: drag handles rendered, list roles, ranked validation error, ranked validation clears on reorder)
- [x] Frontend build succeeds
- [ ] Manual: Create ranked poll → verify drag-and-drop reorders options
- [ ] Manual: Submit ranked poll without reordering → verify validation error shown
- [ ] Manual: Submit ranked poll after reordering → verify vote accepted
- [ ] Manual: Check ranked poll results display shows average rank without vote count

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)